### PR TITLE
Fix link at bottom of page

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Licensed under GPLv2 or any later version, refer to the license.txt file include
 * Patois for original BRAHMA code
 * Smealum, Derrek, Plutoo for publishing the exploit
 * Yellows8 and Plutoo as ideators of it
-* [http://3dbrew.org/](3dbrew community)
+* [3dbrew community](http://3dbrew.org/)
 
 
 


### PR DESCRIPTION
The link to 3DBrew at the bottom of README.md was incorrect
