### PR TITLE
Changed key used for a9lh, made sector generator python agnostic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ $(OUTDIR):
 firm0:
 	@cd payload_stage1 && make
 	@cp $(INDIR)/new3ds90.firm $(OUTDIR)/firm0.bin
-	@dd if=payload_stage1/payload_stage1.bin of=$(OUTDIR)/firm0.bin bs=512 seek=1922 conv=notrunc
+	@dd if=payload_stage1/payload_stage1.bin of=$(OUTDIR)/firm0.bin bs=1 seek=984464 conv=notrunc
 
 firm1:
 	@cp $(INDIR)/new3ds10.firm $(OUTDIR)/firm1.bin

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Some files are needed in order to make the setup compilable, be sure to put the 
 
 * devkitARM r45
 * libctru (ver. 1.0.0)
-* Python 2.7 with PyCcrypto
+* Python with PyCcrypto (2.7 or 3.x should work)
 * GCC or MinGW (Only needed to compile the buildt-in tool, you can download [a pre-compiled windows build here](https://mega.nz/#!j0RkxLjb!4Am-3yDAR9g4VDxY93pWhXVYNDiylSW1cKJntOLfDWU), place it in **common** folder)
 
 ####**Compilation Modes**

--- a/common/payload_stage1.ld
+++ b/common/payload_stage1.ld
@@ -4,7 +4,7 @@ ENTRY(_start)
 
 MEMORY
   {
-  ram : ORIGIN = 0x0808FA00, LENGTH = 0x5k
+  ram : ORIGIN = 0x0808FB90, LENGTH = 0x5k
   }
 
 SECTIONS

--- a/common/sector_generator.py
+++ b/common/sector_generator.py
@@ -1,3 +1,6 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
 from Crypto.Cipher import AES
 from Crypto.Hash import SHA256
 from Crypto.Util import Counter
@@ -15,31 +18,30 @@ ror = lambda val, r_bits, max_bits: \
     (val << (max_bits-(r_bits%max_bits)) & (2**max_bits-1))
 
 def to_bytes(num):
-    numstr = ''
+    numarr = bytearray()
     tmp = num
-    while len(numstr) < 16:
-        numstr += chr(tmp & 0xFF)
+    while len(numarr) < 16:
+        numarr.append(tmp & 0xFF)
         tmp >>= 8
-    return numstr[::-1]
+    return bytes(numarr[::-1])
 
 with open(sys.argv[1], "rb") as sectorFile:
-	secretSector = sectorFile.read(0x200)
-	
-	with open(sys.argv[2], "rb") as otpFile:
-		hash = SHA256.new()
-		otpData = otpFile.read(0x90)
-		hash.update(otpData)
-		keyX = ''.join(hash.hexdigest()[0:32])
-		keyY = ''.join(hash.hexdigest()[32:64])
-		normalKey = rol((rol(int(keyX, 16), 2, 128) ^ int(keyY, 16)) + 0x1FF9E9AAC5FE0408024591DC5D52768A, 87, 128)
-		print normalKey
-		
-		ecbmode = AES.new(to_bytes(normalKey), AES.MODE_ECB)
-		
-		with open(sys.argv[3], "wb") as outFile:
-			for x in xrange(0, 0x20):
-				outFile.seek(x*0x10)
-				if x == 1 :
-					outFile.write(ecbmode.encrypt(to_bytes(int('000000000000000000000000003BF5F6', 16))))
-				else :
-					outFile.write(ecbmode.encrypt(secretSector[x*0x10:(x+1)*0x10]))
+    secretSector = sectorFile.read(0x200)
+
+    with open(sys.argv[2], "rb") as otpFile:
+        hash = SHA256.new()
+        otpData = otpFile.read(0x90)
+        hash.update(otpData)
+        keyX = ''.join(hash.hexdigest()[0:32])
+        keyY = ''.join(hash.hexdigest()[32:64])
+        normalKey = rol((rol(int(keyX, 16), 2, 128) ^ int(keyY, 16)) + 0x1FF9E9AAC5FE0408024591DC5D52768A, 87, 128)
+        print(normalKey)
+        ecbmode = AES.new(to_bytes(normalKey), AES.MODE_ECB)
+
+        with open(sys.argv[3], "wb") as outFile:
+            for x in range(0, 0x20):
+                outFile.seek(x*0x10)
+                if x == 1 :
+                    outFile.write(ecbmode.encrypt(to_bytes(int('0824D3CB4AE94D624DAA526047C59394', 16))))
+                else :
+                    outFile.write(ecbmode.encrypt(secretSector[x*0x10:(x+1)*0x10]))

--- a/payload_stage1/Makefile
+++ b/payload_stage1/Makefile
@@ -126,7 +126,7 @@ $(OUTPUT).elf	:	$(OFILES)
 %.bin: %.elf
 	@$(OBJCOPY) --set-section-flags .bss=alloc,load,contents -O binary $< $@
 	@echo built ... $(notdir $@)
-	@rm -f $(OUTPUT).elf
+	#@rm -f $(OUTPUT).elf
 
 #---------------------------------------------------------------------------------
 # you need a rule like this for each extension you use as binary data

--- a/payload_stage1/source/_start.s
+++ b/payload_stage1/source/_start.s
@@ -1,7 +1,7 @@
 .section .text.start
 .align 4
-.org 0x2B0
 .global _start
+
 _start:
     @ Disable IRQ
     mrs r0, cpsr


### PR DESCRIPTION
I have tested this on my system, and it installs fine using the packer installer. I verified with G9 that the branch instruction was the one expected.

Key: 65293E12560C0BD1DDB5631CB6D95275
FIRM 10.2 is decrypted to as the first instruction: 0xEA01D2DB
Jumps to: 0x0808FB90

The 0x190 offset from 0x0801FA00 was empirically determined. If stage1 is placed before 0x190 after the end of FIRM1's ARM9 section in memory, something seems to overwrite it. 0x190 seems to be the first offset from the end of FIRM1's ARM9 section that is safe.
