### PR TITLE
Makes both stage1 and 2 as position independent executables

### DIFF
--- a/common/payload_stage1.ld
+++ b/common/payload_stage1.ld
@@ -3,9 +3,10 @@ OUTPUT_ARCH(arm)
 ENTRY(_start)
 
 MEMORY
-  {
-  ram : ORIGIN = 0x0808FB90, LENGTH = 0x5k
-  }
+{
+	/* ram : ORIGIN = 0x0808FB90, LENGTH = 0x5k */
+	ram : ORIGIN = 0x00, LENGTH = 0x5k
+}
 
 SECTIONS
 {
@@ -107,7 +108,11 @@ SECTIONS
 		. = ALIGN(4);   /* REQUIRED. LD is flaky without it. */
 	} >ram = 0xff
 	.jcr            : { KEEP (*(.jcr)) } >ram = 0
-	.got            : { *(.got.plt) *(.got) } >ram = 0
+	.got            : {
+		__got_start = .;
+		*(.got.plt) *(.got)
+	} >ram = 0
+	__got_end = .;
 
 	.data ALIGN(4) : 	{
 		__data_start = ABSOLUTE(.);

--- a/common/payload_stage2.ld
+++ b/common/payload_stage2.ld
@@ -4,7 +4,7 @@ ENTRY(_start)
 
 MEMORY
   {
-  ram : ORIGIN = 0x08006000, LENGTH = 0x10000K
+  ram : ORIGIN = 0x00, LENGTH = 0x10000K
   }
 
 SECTIONS
@@ -107,7 +107,11 @@ SECTIONS
 		. = ALIGN(4);   /* REQUIRED. LD is flaky without it. */
 	} >ram = 0xff
 	.jcr            : { KEEP (*(.jcr)) } >ram = 0
-	.got            : { *(.got.plt) *(.got) } >ram = 0
+	.got            : {
+		__got_start = .;
+		*(.got.plt) *(.got)
+	} >ram = 0
+	__got_end = .;
 
 	.data ALIGN(4) : 	{
 		__data_start = ABSOLUTE(.);

--- a/payload_stage1/Makefile
+++ b/payload_stage1/Makefile
@@ -29,9 +29,9 @@ INCLUDES	:=	include source source/fatfs
 #---------------------------------------------------------------------------------
 # options for code generation
 #---------------------------------------------------------------------------------
-ARCH	:=	-mthumb -mthumb-interwork
+ARCH	:=	-mthumb -Wl,--use-blx
 
-CFLAGS	:=	-g -Wall -O2\
+CFLAGS	:=	-g -Wall -O2 -fPIC -flto -nostdlib\
 			-march=armv5te -mtune=arm946e-s -fomit-frame-pointer\
 			-ffast-math -std=c99\
 			$(ARCH)
@@ -40,8 +40,9 @@ CFLAGS	+=	$(INCLUDE)
 
 CXXFLAGS	:= $(CFLAGS) -fno-rtti -fno-exceptions
 
-ASFLAGS	:=	-g $(ARCH) 
-LDFLAGS	=	-nostartfiles -g $(ARCH) -Wl,-Map,$(TARGET).map
+ASFLAGS	:=	-g $(ARCH)
+LDFLAGS	=	-nostartfiles -g $(ARCH) -Wl,-Map,$(TARGET).map -nostdlib \
+			-Wl,--use-blx -fPIC
 
 LDFLAGS += --specs=../../common/payload_stage1.specs
 
@@ -88,7 +89,7 @@ endif
 #---------------------------------------------------------------------------------
 
 export OFILES	:= $(addsuffix .o,$(BINFILES)) \
-			$(SFILES:.s=.o) $(CPPFILES:.cpp=.o) $(CFILES:.c=.o) 
+			$(SFILES:.s=.o) $(CPPFILES:.cpp=.o) $(CFILES:.c=.o)
 
 export INCLUDE	:=	$(foreach dir,$(INCLUDES),-I$(CURDIR)/$(dir)) \
 			$(foreach dir,$(LIBDIRS),-I$(dir)/include) \
@@ -105,7 +106,7 @@ $(BUILD):
 	@[ -d $(OUTPUT_D) ] || mkdir -p $(OUTPUT_D)
 	@[ -d $(BUILD) ] || mkdir -p $(BUILD)
 	@make --no-print-directory -C $(BUILD) -f $(CURDIR)/Makefile
-		
+
 #---------------------------------------------------------------------------------
 clean:
 	@echo clean ...
@@ -126,7 +127,7 @@ $(OUTPUT).elf	:	$(OFILES)
 %.bin: %.elf
 	@$(OBJCOPY) --set-section-flags .bss=alloc,load,contents -O binary $< $@
 	@echo built ... $(notdir $@)
-	#@rm -f $(OUTPUT).elf
+	@rm -f $(OUTPUT).elf
 
 #---------------------------------------------------------------------------------
 # you need a rule like this for each extension you use as binary data

--- a/payload_stage1/source/_start.s
+++ b/payload_stage1/source/_start.s
@@ -1,13 +1,59 @@
 .section .text.start
 .align 4
 .global _start
+.extern flush_all_caches
 
 _start:
     @ Disable IRQ
     mrs r0, cpsr
     orr r0, r0, #0x80
     msr cpsr_c, r0
-    
+
+    @ Change the stack pointer
+    mov sp, #0x27000000
+
+    @ Set up relocation register (r9)
+    @   this instruction is 16 bytes away from the start, takes into account the 8
+    @   bytes PC is ahead, meaning pc - 24 == start in memory
+    sub r9, pc, #24
+
+    @ Disable caches and MPU
+    ldr r0, =disable_mpu_and_caching
+    add r0, r0, r9
+    blx r0
+
+    @ Flush caches
+    ldr r0, =flush_all_caches
+    add r0, r0, r9
+    blx r0
+
+    @ Setup GOT table (just in case)
+    ldr r0, =__got_start
+    ldr r1, =__got_end
+    mov r2, r9
+
+    ldr r3, =relocate_section
+    add r3, r3, r9
+    blx r3
+
+    @ Set MPU table
+    ldr r0, =setup_mpu_table
+    add r0, r0, r9
+    blx r0
+
+    @ Enable caches and MPU
+    ldr r0, =enable_mpu_and_caching
+    add r0, r0, r9
+    blx r0
+
+    ldr r0, =main
+    add r0, r0, r9
+    blx r0
+
+.die:
+    b .die
+
+disable_mpu_and_caching:
     @ Disable caches and MPU
     mrc p15, 0, r0, c1, c0, 0  @ read control register
     bic r0, r0, #(1<<12)       @ - instruction cache enable
@@ -15,45 +61,29 @@ _start:
     bic r0, r0, #(1<<0)        @ - mpu enable
     mcr p15, 0, r0, c1, c0, 0  @ write control register
 
-    @ Flush caches
-    ldr r0, =0xFFFF0830 @ Nintendo's flush function in unprot. bootrom
-    blx r0
+    bx lr
 
-    @ Change the stack pointer
-    mov sp, #0x27000000
+enable_mpu_and_caching:
+    @ Enable caches and MPU
+    mrc p15, 0, r0, c1, c0, 0  @ read control register
+    orr r0, r0, #(1<<12)       @ - instruction cache enable
+    orr r0, r0, #(1<<2)        @ - data cache enable
+    orr r0, r0, #(1<<0)        @ - mpu enable
+    mcr p15, 0, r0, c1, c0, 0  @ write control register
 
-    @ Set up GOT
-    sub r3, pc, #52
-    push {r3}
-    ldr r0, =__got_start
-    ldr r1, =__got_end
+    bx lr
 
-    add r0, r0, r3
-    add r1, r1, r3
-
-    got_init:
-    cmp r0, r1
-    beq gotinit_done
-    ldr r2, [r0]
-    add r2, r2, r3
-    str r2, [r0], #4
-    b got_init
-    gotinit_done:
-
-    @ Give read/write access to all the memory regions
-    ldr r0, =0x33333333
-    mcr p15, 0, r0, c5, c0, 2 @ write data access
-    mcr p15, 0, r0, c5, c0, 3 @ write instruction access
-
+setup_mpu_table:
+    push {r4-r7}
     @ Set MPU permissions and cache settings
-    ldr r0, =0xFFFF001D	@ ffff0000 32k
-    ldr r1, =0x01FF801D	@ 01ff8000 32k
-    ldr r2, =0x08000027	@ 08000000 1M
-    ldr r3, =0x10000021	@ 10000000 128k
-    ldr r4, =0x10100025	@ 10100000 512k
-    ldr r5, =0x20000035	@ 20000000 128M
-    ldr r6, =0x1FF00027	@ 1FF00000 1M
-    ldr r7, =0x1800002D	@ 18000000 8M
+    ldr r0, =0xFFFF001D @ ffff0000 32k
+    ldr r1, =0x01FF801D @ 01ff8000 32k
+    ldr r2, =0x08000027 @ 08000000 1M
+    ldr r3, =0x10000021 @ 10000000 128k
+    ldr r4, =0x10100025 @ 10100000 512k
+    ldr r5, =0x20000035 @ 20000000 128M
+    ldr r6, =0x1FF00027 @ 1FF00000 1M
+    ldr r7, =0x1800002D @ 18000000 8M
     mcr p15, 0, r0, c6, c0, 0
     mcr p15, 0, r1, c6, c1, 0
     mcr p15, 0, r2, c6, c2, 0
@@ -65,20 +95,31 @@ _start:
     mov r0, #0x25
     mcr p15, 0, r0, c2, c0, 0  @ data cacheable
     mcr p15, 0, r0, c2, c0, 1  @ instruction cacheable
-    mov r0, #0x5 @ Fixes payloads which don't like FCRAM as "data bufferable"
     mcr p15, 0, r0, c3, c0, 0  @ data bufferable
 
-    @ Enable caches and MPU
-    mrc p15, 0, r0, c1, c0, 0  @ read control register
-    orr r0, r0, #(1<<12)       @ - instruction cache enable
-    orr r0, r0, #(1<<2)        @ - data cache enable
-    orr r0, r0, #(1<<0)        @ - mpu enable
-    mcr p15, 0, r0, c1, c0, 0  @ write control register
+    @ Give read/write access to all the memory regions
+    ldr r0, =0x33333333
+    mcr p15, 0, r0, c5, c0, 2 @ write data access
+    mcr p15, 0, r0, c5, c0, 3 @ write instruction access
 
-    pop {r3}
-    ldr r0, =main
-    add r0, r0, r3
-    blx r0
+    pop {r4-r7}
+    bx lr
 
-.die:
-    b .die
+@ r0 - region start
+@ r1 - region end
+@ r2 - relocation base (usually starting PC address)
+relocate_section:
+    add r0, r0, r2
+    add r1, r1, r2
+
+    .Lreloc_init:
+    cmp r0, r1
+    beq .Lrelocinit_done
+    ldr r3, [r0]
+    add r3, r2, r3
+    str r3, [r0], #4
+    b .Lreloc_init
+    .Lrelocinit_done:
+
+    bx lr
+

--- a/payload_stage1/source/flush.h
+++ b/payload_stage1/source/flush.h
@@ -1,0 +1,7 @@
+#ifndef FLUSH_H_
+#define FLUSH_H_
+
+void flush_all_caches(void);
+
+#endif//FLUSH_H_
+

--- a/payload_stage1/source/flush.s
+++ b/payload_stage1/source/flush.s
@@ -1,0 +1,18 @@
+.arm
+.global flush_all_caches
+.type   flush_all_caches STT_FUNC
+
+@void flush_all_caches(void)
+flush_all_caches:
+	push {lr}
+	@ Flush caches
+	ldr r0, =0xFFFF0830 @ Nintendo's flush function in unprot. bootrom
+	blx r0
+
+	@ flush instruction cache, it's not flushed by Nintendo's function
+	mov r0, #0
+	mcr p15, 0, r0, c7, c5, 0
+
+	pop {lr}
+	bx lr
+

--- a/payload_stage1/source/main.c
+++ b/payload_stage1/source/main.c
@@ -1,5 +1,6 @@
 #include "common.h"
 #include "sdmmc.h"
+#include "flush.h"
 
 int main()
 {
@@ -8,7 +9,7 @@ int main()
 	*(vu32*)0x10000020 = 0x340;
 	sdmmc_sdcard_init();
 	sdmmc_nand_readsectors(0x5C000, 0x20, (u8*)0x08006000);
-	
+	flush_all_caches();
 	// Jump to secondary payload
 	((void (*)())0x08006000)();
 	

--- a/payload_stage2/Makefile
+++ b/payload_stage2/Makefile
@@ -29,11 +29,11 @@ INCLUDES	:=	include source source/fatfs
 #---------------------------------------------------------------------------------
 # options for code generation
 #---------------------------------------------------------------------------------
-ARCH	:=	-mthumb -mthumb-interwork
+ARCH	:=	-mthumb -Wl,--use-blx
 
-CFLAGS	:=	-g -Wall -Wno-unused-function -O2\
+CFLAGS	:=	-g -Wall -fPIC -Wno-unused-function -O2\
 			-march=armv5te -mtune=arm946e-s -fomit-frame-pointer\
-			-ffast-math -std=c11\
+			-ffast-math -std=c11 -nodefaultlibs\
 			$(ARCH)
 
 CFLAGS	+=	$(INCLUDE)
@@ -41,12 +41,13 @@ CFLAGS	+=	$(INCLUDE)
 CXXFLAGS	:= $(CFLAGS) -fno-rtti -fno-exceptions
 
 ASFLAGS	:=	-g $(ARCH)
-LDFLAGS	=	-nostartfiles -g $(ARCH) -Wl,-Map,$(TARGET).map
+LDFLAGS	=	-nostartfiles -g $(ARCH) -Wl,-Map,$(TARGET).map -nostdlib \
+			-Wl,--use-blx -fPIC
 
 LDFLAGS += --specs=../../common/payload_stage2.specs
 
 
-LIBS	:=
+LIBS	:= -lgcc
 
 #---------------------------------------------------------------------------------
 # list of directories containing libraries, this must be the top level containing

--- a/payload_stage2/source/_start.s
+++ b/payload_stage2/source/_start.s
@@ -5,7 +5,26 @@
 _start:
 _init:
 
-    bl main
+    @ Set up GOT
+    sub r3, pc, #8
+    ldr r0, =__got_start
+    ldr r1, =__got_end
+
+    add r0, r0, r3
+    add r1, r1, r3
+
+    got_init:
+    cmp r0, r1
+    beq gotinit_done
+    ldr r2, [r0]
+    add r2, r2, r3
+    str r2, [r0], #4
+    b got_init
+    gotinit_done:
+
+    ldr r0, =main
+    add r0, r0, r3
+    blx r0
 
 .die:
     b .die

--- a/payload_stage2/source/_start.s
+++ b/payload_stage2/source/_start.s
@@ -2,29 +2,41 @@
 .align 4
 .arm
 .global _start
+.extern flush_all_caches
 _start:
 _init:
 
     @ Set up GOT
-    sub r3, pc, #8
+    sub r9, pc, #8
     ldr r0, =__got_start
     ldr r1, =__got_end
+    mov r2, r9
 
-    add r0, r0, r3
-    add r1, r1, r3
-
-    got_init:
-    cmp r0, r1
-    beq gotinit_done
-    ldr r2, [r0]
-    add r2, r2, r3
-    str r2, [r0], #4
-    b got_init
-    gotinit_done:
+    ldr r3, =relocate_section
+    add r3, r3, r9
+    blx r3
 
     ldr r0, =main
-    add r0, r0, r3
+    add r0, r0, r9
     blx r0
 
 .die:
     b .die
+
+@ r0 - region start
+@ r1 - region end
+@ r2 - relocation base (usually starting PC address)
+relocate_section:
+    add r0, r0, r2
+    add r1, r1, r2
+
+    .Lreloc_init:
+    cmp r0, r1
+    beq .Lrelocinit_done
+    ldr r3, [r0]
+    add r3, r2, r3
+    str r3, [r0], #4
+    b .Lreloc_init
+    .Lrelocinit_done:
+
+    bx lr

--- a/payload_stage2/source/flush.h
+++ b/payload_stage2/source/flush.h
@@ -1,0 +1,7 @@
+#ifndef FLUSH_H_
+#define FLUSH_H_
+
+void flush_all_caches(void);
+
+#endif//FLUSH_H_
+

--- a/payload_stage2/source/flush.s
+++ b/payload_stage2/source/flush.s
@@ -1,0 +1,18 @@
+.arm
+.global flush_all_caches
+.type   flush_all_caches STT_FUNC
+
+@void flush_all_caches(void)
+flush_all_caches:
+	push {lr}
+	@ Flush caches
+	ldr r0, =0xFFFF0830 @ Nintendo's flush function in unprot. bootrom
+	blx r0
+
+	@ flush instruction cache, it's not flushed by Nintendo's function
+	mov r0, #0
+	mcr p15, 0, r0, c7, c5, 0
+
+	pop {lr}
+	bx lr
+

--- a/payload_stage2/source/main.c
+++ b/payload_stage2/source/main.c
@@ -13,9 +13,19 @@
 extern u8 screen_init_bin[];
 extern u32 screen_init_bin_size;
 
+static inline void* copy_memory(void *dst, void *src, size_t amount)
+{
+	void *result = dst;
+	while (amount--)
+	{
+		*((char*)(dst++)) = *((char*)(src++));
+	}
+	return result;
+}
+
 void ownArm11()
 {
-	memcpy((void*)A11_PAYLOAD_LOC, screen_init_bin, screen_init_bin_size);
+	copy_memory((void*)A11_PAYLOAD_LOC, screen_init_bin, screen_init_bin_size);
 	*((u32*)0x1FFAED80) = 0xE51FF004;
 	*((u32*)0x1FFAED84) = A11_PAYLOAD_LOC;
 	for(int i = 0; i < 0x80000; i++)

--- a/payload_stage2/source/screen.c
+++ b/payload_stage2/source/screen.c
@@ -1,0 +1,41 @@
+#include "screen.h"
+#include "i2c.h"
+
+#define TOP_SCREEN_SIZE	(400 * 240 * 3 / 4)
+#define BOT_SCREEN_SIZE	(320 * 240 * 3 / 4)
+
+void setFramebuffers(void)
+{
+	//Gateway
+	*(vu32*)0x80FFFC0 = 0x18300000;  // framebuffer 1 top left
+	*(vu32*)0x80FFFC4 = 0x18300000;  // framebuffer 2 top left
+	*(vu32*)0x80FFFC8 = 0x18300000;  // framebuffer 1 top right
+	*(vu32*)0x80FFFCC = 0x18300000;  // framebuffer 2 top right
+	*(vu32*)0x80FFFD0 = 0x18346500;  // framebuffer 1 bottom
+	*(vu32*)0x80FFFD4 = 0x18346500;  // framebuffer 2 bottom
+	*(vu32*)0x80FFFD8 = 1;  // framebuffer select top
+	*(vu32*)0x80FFFDC = 1;  // framebuffer select bottom
+
+	//CakeBrah
+	*(vu32*)0x23FFFE00 = 0x18300000;
+	*(vu32*)0x23FFFE04 = 0x18300000;
+	*(vu32*)0x23FFFE08 = 0x18346500;
+}
+
+void clearScreens(void)
+{
+	for(u32 i = 0; i < (TOP_SCREEN_SIZE); i++)
+	{
+		*((vu32*)0x18300000 + i) = 0;
+	}
+
+	for(u32 i = 0; i < (BOT_SCREEN_SIZE); i++)
+	{
+		*((vu32*)0x18346500 + i) = 0;
+	}
+}
+
+void turnOnBacklight(void)
+{
+	i2cWriteRegister(3, 0x22, 0x2A); // 0x2A -> boot into firm with no backlight
+}

--- a/payload_stage2/source/screen.h
+++ b/payload_stage2/source/screen.h
@@ -1,0 +1,6 @@
+#pragma once
+
+void setFramebuffers(void);
+void clearScreens(void);
+void turnOnBacklight(void);
+

--- a/payload_stage2/source/screen_init.c
+++ b/payload_stage2/source/screen_init.c
@@ -1,8 +1,0 @@
-#include "i2c.h"
-
-void screenInit()
-{
-
-    i2cWriteRegister(3, 0x22, 0x2A); // 0x2A -> boot into firm with no backlight
-
-}

--- a/payload_stage2/source/screen_init.h
+++ b/payload_stage2/source/screen_init.h
@@ -1,1 +1,0 @@
-void screenInit();

--- a/screen_init/source/screen_init/screen_init.c
+++ b/screen_init/source/screen_init/screen_init.c
@@ -1,223 +1,118 @@
 #include <inttypes.h>
 
-#define BRIGHTNESS 0xFF
+#define BRIGHTNESS 0x39
 #define FB_TOP_LEFT 0x18300000
 #define FB_TOP_RIGHT 0x18300000
 #define FB_BOTTOM 0x18346500
 
-void regSet();
+static inline void regSet();
 
 void __attribute__ ((naked)) a11Entry()
 {
-    __asm__ ("ldr r0,=_stack\n\t mov sp, r0");
-    regSet();
+	__asm__ (
+		"CPSID aif\n\t" //Disable interrupts
+		"ldr r0,=_stack\n\t"
+		"mov sp, r0"
+	);
+
+	regSet();
 }
 
-void regSet()
+static inline void regSet()
 {
+	volatile uint32_t *entry = (uint32_t *)0x1FFFFFF8;
 
-    volatile uint32_t *entry = (uint32_t *)0x1FFFFFF8;
+	*(volatile uint32_t*)0x10141200 = 0x1007F;
+	*(volatile uint32_t*)0x10202014 = 0x00000001;
+	*(volatile uint32_t*)0x1020200C &= 0xFFFEFFFE;
 
-    // pdn sub_101D98
-    *((volatile uint32_t*)0x10141200) = 0x10000; // PDN_GPU_CNT
-    // Delay here pls
-    for(volatile int i = 0xC; i > 0; i-=2);
-    *((volatile uint32_t*)0x10141200) = 0x1007F; // PDN_GPU_CNT
+	*(volatile uint32_t*)0x10202240 = BRIGHTNESS;
+	*(volatile uint32_t*)0x10202A40 = BRIGHTNESS;
+	*(volatile uint32_t*)0x10202244 = 0x1023E;
+	*(volatile uint32_t*)0x10202A44 = 0x1023E;
 
-    // gsp sub_1021F4 init_screen_maybe
-    *((volatile uint32_t*)0x10400004) |= 0x100;
-    *((volatile uint32_t*)0x10400030) &= 0xFFFFF0FF;
+	// Top screen
+	*(volatile uint32_t*)0x10400400 = 0x000001c2;
+	*(volatile uint32_t*)0x10400404 = 0x000000d1;
+	*(volatile uint32_t*)0x10400408 = 0x000001c1;
+	*(volatile uint32_t*)0x1040040c = 0x000001c1;
+	*(volatile uint32_t*)0x10400410 = 0x00000000;
+	*(volatile uint32_t*)0x10400414 = 0x000000cf;
+	*(volatile uint32_t*)0x10400418 = 0x000000d1;
+	*(volatile uint32_t*)0x1040041c = 0x01c501c1;
+	*(volatile uint32_t*)0x10400420 = 0x00010000;
+	*(volatile uint32_t*)0x10400424 = 0x0000019d;
+	*(volatile uint32_t*)0x10400428 = 0x00000002;
+	*(volatile uint32_t*)0x1040042c = 0x00000192;
+	*(volatile uint32_t*)0x10400430 = 0x00000192;
+	*(volatile uint32_t*)0x10400434 = 0x00000192;
+	*(volatile uint32_t*)0x10400438 = 0x00000001;
+	*(volatile uint32_t*)0x1040043c = 0x00000002;
+	*(volatile uint32_t*)0x10400440 = 0x01960192;
+	*(volatile uint32_t*)0x10400444 = 0x00000000;
+	*(volatile uint32_t*)0x10400448 = 0x00000000;
+	*(volatile uint32_t*)0x1040045C = 0x00f00190;
+	*(volatile uint32_t*)0x10400460 = 0x01c100d1;
+	*(volatile uint32_t*)0x10400464 = 0x01920002;
+	*(volatile uint32_t*)0x10400468 = 0x18300000;
+	*(volatile uint32_t*)0x10400470 = 0x80341;
+	*(volatile uint32_t*)0x10400474 = 0x00010501;
+	*(volatile uint32_t*)0x10400478 = 0;
+	*(volatile uint32_t*)0x10400490 = 0x000002D0;
+	*(volatile uint32_t*)0x1040049C = 0x00000000;
 
-    // sub_107A34
-    // Top screen
-    *((volatile uint32_t*)0x10400400) = 0x000001c2;
-    *((volatile uint32_t*)0x10400404) = 0x000000d1;
-    *((volatile uint32_t*)0x10400408) = 0x000001c1;
-    *((volatile uint32_t*)0x1040040c) = 0x000001c1;
-    *((volatile uint32_t*)0x10400410) = 0x00000000;
-    *((volatile uint32_t*)0x10400414) = 0x000000cf;
-    *((volatile uint32_t*)0x10400418) = 0x000000d1;
-    *((volatile uint32_t*)0x1040041c) = 0x01c501c1;
-    *((volatile uint32_t*)0x10400420) = 0x00010000;
-    *((volatile uint32_t*)0x10400424) = 0x0000019d;
-    *((volatile uint32_t*)0x10400428) = 0x00000002;
-    *((volatile uint32_t*)0x1040042c) = 0x00000192;
-    *((volatile uint32_t*)0x10400430) = 0x00000192;
-    *((volatile uint32_t*)0x10400434) = 0x00000192;
-    *((volatile uint32_t*)0x10400438) = 0x00000001;
-    *((volatile uint32_t*)0x1040043c) = 0x00000002;
-    *((volatile uint32_t*)0x10400440) = 0x01960192;
-    *((volatile uint32_t*)0x10400444) = 0x00000000;
-    *((volatile uint32_t*)0x10400448) = 0x00000000;
-    *((volatile uint32_t*)0x1040044c) = 0x0000ff00;
-    *((volatile uint32_t*)0x1040045c) = 0x019000f0;
-    *((volatile uint32_t*)0x10400460) = 0x01c100d1;
-    *((volatile uint32_t*)0x10400464) = 0x01920002;
-    *((volatile uint32_t*)0x10400490) = 0x000003c0;
-    *((volatile uint32_t*)0x1040049c) = 0x00000000;
-    *((volatile uint32_t*)0x10400468) = 0x18000000;
-    *((volatile uint32_t*)0x1040046c) = 0x18000000;
-    *((volatile uint32_t*)0x10400494) = 0x18000000;
-    *((volatile uint32_t*)0x10400498) = 0x18000000;
-    *((volatile uint32_t*)0x10400470) = 0x00080340;
-    *((volatile uint32_t*)0x10400480) = 0x00000000;
- 
-    for(int i = 0, temp = 0; i < 256; i++)
-        *((volatile uint32_t*)0x10400484) = 0x10101 * i;
-   
-    // Bottom screen
-    *((volatile uint32_t*)0x10400500) = 0x000001c2;
-    *((volatile uint32_t*)0x10400504) = 0x000000d1;
-    *((volatile uint32_t*)0x10400508) = 0x000001c1;
-    *((volatile uint32_t*)0x1040050c) = 0x000001c1;
-    *((volatile uint32_t*)0x10400510) = 0x000000cd;
-    *((volatile uint32_t*)0x10400514) = 0x000000cf;
-    *((volatile uint32_t*)0x10400518) = 0x000000d1;
-    *((volatile uint32_t*)0x1040051c) = 0x01c501c1;
-    *((volatile uint32_t*)0x10400520) = 0x00010000;
-    *((volatile uint32_t*)0x10400524) = 0x0000019d;
-    *((volatile uint32_t*)0x10400528) = 0x00000052;
-    *((volatile uint32_t*)0x1040052c) = 0x00000192;
-    *((volatile uint32_t*)0x10400530) = 0x00000192;
-    *((volatile uint32_t*)0x10400534) = 0x0000004f;
-    *((volatile uint32_t*)0x10400538) = 0x00000050;
-    *((volatile uint32_t*)0x1040053c) = 0x00000052;
-    *((volatile uint32_t*)0x10400540) = 0x01970193;
-    *((volatile uint32_t*)0x10400544) = 0x00000000;
-    *((volatile uint32_t*)0x10400548) = 0x00000011;
-    *((volatile uint32_t*)0x1040054c) = 0x000000ff;
-    *((volatile uint32_t*)0x1040055c) = 0x014000f0;
-    *((volatile uint32_t*)0x10400560) = 0x01c100d1;
-    *((volatile uint32_t*)0x10400564) = 0x01920052;
-    *((volatile uint32_t*)0x10400590) = 0x000003c0;
-    *((volatile uint32_t*)0x1040059c) = 0x00000000;
-    *((volatile uint32_t*)0x10400568) = 0x18000000;
-    *((volatile uint32_t*)0x1040056c) = 0x18000000;
-    *((volatile uint32_t*)0x10400594) = 0x18000000;
-    *((volatile uint32_t*)0x10400598) = 0x18000000;
-    *((volatile uint32_t*)0x10400570) = 0x00080301;
-    *((volatile uint32_t*)0x10400580) = 0x00000000;
-   
-    for(int i = 0, temp = 0; i < 256; i++)
-        *((volatile uint32_t*)0x10400584) = 0x10101 * i;
+	// Disco register
+	for(volatile uint32_t i = 0; i < 256; i++)
+		*(volatile uint32_t*)0x10400484 = 0x10101 * i;
 
-    *((volatile uint32_t*)0x10400478) = 0x00000000;
-    *((volatile uint32_t*)0x10400578) = 0x00000000;
-    *((volatile uint32_t*)0x10400474) = 0x00010501;
-    *((volatile uint32_t*)0x10400574) = 0x00010501;
+	// Bottom screen
+	*(volatile uint32_t*)0x10400500 = 0x000001c2;
+	*(volatile uint32_t*)0x10400504 = 0x000000d1;
+	*(volatile uint32_t*)0x10400508 = 0x000001c1;
+	*(volatile uint32_t*)0x1040050c = 0x000001c1;
+	*(volatile uint32_t*)0x10400510 = 0x000000cd;
+	*(volatile uint32_t*)0x10400514 = 0x000000cf;
+	*(volatile uint32_t*)0x10400518 = 0x000000d1;
+	*(volatile uint32_t*)0x1040051c = 0x01c501c1;
+	*(volatile uint32_t*)0x10400520 = 0x00010000;
+	*(volatile uint32_t*)0x10400524 = 0x0000019d;
+	*(volatile uint32_t*)0x10400528 = 0x00000052;
+	*(volatile uint32_t*)0x1040052c = 0x00000192;
+	*(volatile uint32_t*)0x10400530 = 0x00000192;
+	*(volatile uint32_t*)0x10400534 = 0x0000004f;
+	*(volatile uint32_t*)0x10400538 = 0x00000050;
+	*(volatile uint32_t*)0x1040053c = 0x00000052;
+	*(volatile uint32_t*)0x10400540 = 0x01980194;
+	*(volatile uint32_t*)0x10400544 = 0x00000000;
+	*(volatile uint32_t*)0x10400548 = 0x00000011;
+	*(volatile uint32_t*)0x1040055C = 0x00f00140;
+	*(volatile uint32_t*)0x10400560 = 0x01c100d1;
+	*(volatile uint32_t*)0x10400564 = 0x01920052;
+	*(volatile uint32_t*)0x10400568 = 0x18300000 + 0x46500;
+	*(volatile uint32_t*)0x10400570 = 0x80301;
+	*(volatile uint32_t*)0x10400574 = 0x00010501;
+	*(volatile uint32_t*)0x10400578 = 0;
+	*(volatile uint32_t*)0x10400590 = 0x000002D0;
+	*(volatile uint32_t*)0x1040059C = 0x00000000;
 
-    // sub_10915C
-    *((volatile uint32_t*)0x10202014) = 0x00000001;
-    *((volatile uint32_t*)0x10202204) = 0x00000000; // color fill disable
-    *((volatile uint32_t*)0x10202a04) = 0x00000000; // color fill disable
-    *((volatile uint32_t*)0x1020200C) &= 0xFFFEFFFE;// wtf register
-   
-    *((volatile uint32_t*)0x10202240) = BRIGHTNESS;
-    *((volatile uint32_t*)0x10202244) = 0x1023E;
-   
-    *((volatile uint32_t*)0x10202A40) = BRIGHTNESS;
-    *((volatile uint32_t*)0x10202A44) = 0x1023E;
-  
-    // After hm call cmd 0x00160042 to acquire rights
-    // and cmd 00130042 RegisterInterruptRelayQueue
-    *((volatile uint32_t*)0x10401000) = 0;
-    *((volatile uint32_t*)0x10401080) = 0x12345678;
-    *((volatile uint32_t*)0x104010C0) = 0xFFFFFFF0;
-    *((volatile uint32_t*)0x104010D0) = 1;
-    *((volatile uint32_t*)0x10400400) = 0x000001c2;
-    *((volatile uint32_t*)0x10400404) = 0x000000d1;
-    *((volatile uint32_t*)0x10400408) = 0x000001c1;
-    *((volatile uint32_t*)0x1040040c) = 0x000001c1;
-    *((volatile uint32_t*)0x10400410) = 0x00000000;
-    *((volatile uint32_t*)0x10400414) = 0x000000cf;
-    *((volatile uint32_t*)0x10400418) = 0x000000d1;
-    *((volatile uint32_t*)0x1040041c) = 0x01c501c1;
-    *((volatile uint32_t*)0x10400420) = 0x00010000;
-    *((volatile uint32_t*)0x10400424) = 0x0000019d;
-    *((volatile uint32_t*)0x10400428) = 0x00000002;
-    *((volatile uint32_t*)0x1040042c) = 0x00000192;
-    *((volatile uint32_t*)0x10400430) = 0x00000192;
-    *((volatile uint32_t*)0x10400434) = 0x00000192;
-    *((volatile uint32_t*)0x10400438) = 0x00000001;
-    *((volatile uint32_t*)0x1040043c) = 0x00000002;
-    *((volatile uint32_t*)0x10400440) = 0x01960192;
-    *((volatile uint32_t*)0x10400444) = 0x00000000;
-    *((volatile uint32_t*)0x10400448) = 0x00000000;
-    *((volatile uint32_t*)0x1040045c) = 0x019000f0;
-    *((volatile uint32_t*)0x10400460) = 0x01c100d1;
-    *((volatile uint32_t*)0x10400464) = 0x01920002;
-    *((volatile uint32_t*)0x10400470) = 0x00080340;
-    *((volatile uint32_t*)0x1040049C) = 0x00000000;
-    // (122500 log)
-    *((volatile uint32_t*)0x10400500) = 0x000001c2;
-    *((volatile uint32_t*)0x10400504) = 0x000000d1;
-    *((volatile uint32_t*)0x10400508) = 0x000001c1;
-    *((volatile uint32_t*)0x1040050c) = 0x000001c1;
-    *((volatile uint32_t*)0x10400510) = 0x000000cd;//diff
-    *((volatile uint32_t*)0x10400514) = 0x000000cf;
-    *((volatile uint32_t*)0x10400518) = 0x000000d1;
-    *((volatile uint32_t*)0x1040051c) = 0x01c501c1;
-    *((volatile uint32_t*)0x10400520) = 0x00010000;
-    *((volatile uint32_t*)0x10400524) = 0x0000019d;
-    *((volatile uint32_t*)0x10400528) = 0x00000052;//diff
-    *((volatile uint32_t*)0x1040052c) = 0x00000192;
-    *((volatile uint32_t*)0x10400530) = 0x00000192;
-    *((volatile uint32_t*)0x10400534) = 0x0000004f;//diff
-    *((volatile uint32_t*)0x10400538) = 0x00000050;//diff
-    *((volatile uint32_t*)0x1040053c) = 0x00000052;//diff
-    *((volatile uint32_t*)0x10400540) = 0x01980194;//diff
-    *((volatile uint32_t*)0x10400544) = 0x00000000;
-    *((volatile uint32_t*)0x10400548) = 0x00000011;//diff
-    *((volatile uint32_t*)0x1040055c) = 0x014000f0;//diff
-    *((volatile uint32_t*)0x10400560) = 0x01c100d1;
-    *((volatile uint32_t*)0x10400564) = 0x01920052;//diff
-    *((volatile uint32_t*)0x1040059C) = 0x00000000;
-    //(122860 log)
-   
-    *((volatile uint32_t*)0x10400468) = FB_TOP_LEFT;
-    *((volatile uint32_t*)0x1040046c) = FB_TOP_LEFT;
-    *((volatile uint32_t*)0x10400494) = FB_TOP_RIGHT;
-    *((volatile uint32_t*)0x10400498) = FB_TOP_RIGHT;
-   
-    *((volatile uint32_t*)0x10400568) = FB_BOTTOM;
-    *((volatile uint32_t*)0x1040056c) = FB_BOTTOM;
-   
-    *((volatile uint32_t*)0x10400478) = 0x00000001;
-    *((volatile uint32_t*)0x10400578) = 0x00000001;
-   
-    // dma stuffs
-    // skipped
-   
-    // called by hm
-    *((volatile uint32_t*)0x10400004) = 0x00070100;
-   
-    //(123030 log)
-    *((volatile uint32_t*)0x1040001C) &= 0xFFFFFFFD;
-    *((volatile uint32_t*)0x1040002C) &= 0xFFFFFFFD;
-    *((volatile uint32_t*)0x10400050) = 0x22221200;
-    *((volatile uint32_t*)0x10400054) = 0xFF2;
-   
-    //(123097 log)
-    *((volatile uint32_t*)0x10400474) = 0x00010501;
-    *((volatile uint32_t*)0x10400574) = 0x00010501;
-   
-    // from hm
-    // command list skipped
-    *((volatile uint32_t*)0x10400470) = 0x00080341;
-    *((volatile uint32_t*)0x10400490) = 0x000002D0;
-   
-    *((volatile uint32_t*)0x10400570) = 0x00080301;
-    *((volatile uint32_t*)0x10400590) = 0x000002D0;
-   
-    *((volatile uint32_t*)0x10401000) = 0x00000000;
+	// Disco register
+	for(volatile uint32_t i = 0; i < 256; i++)
+		*(volatile uint32_t*)0x10400584 = 0x10101 * i;
 
-    // Reset the entry
-    *entry = 0;
+	*(volatile uint32_t*)0x10400468 = FB_TOP_LEFT;
+	*(volatile uint32_t*)0x1040046c = FB_TOP_LEFT;
+	*(volatile uint32_t*)0x10400494 = FB_TOP_RIGHT;
+	*(volatile uint32_t*)0x10400498 = FB_TOP_RIGHT;
+	*(volatile uint32_t*)0x10400568 = FB_BOTTOM;
+	*(volatile uint32_t*)0x1040056c = FB_BOTTOM;
 
-    // Wait for entry to be set
-    while(!*entry);
-   
-    // Jump
-    ((void (*)())*entry)();
- 
+	// Reset the entry
+	*entry = 0;
+
+	// Wait for entry to be set
+	while(!*entry);
+
+	// Jump
+	((void (*)())*entry)();
 }
+


### PR DESCRIPTION
These commits implement stage1 and 2 as position independent executables, meaning they can be placed at any address, and they should still run. Stage2 doesn't benefit from this too much (although this does mean it can easily be moved around now), but stage1 can now be moved without having to modify linker scripts if for some reason the key needs to change.

I have tested these changes on my o3DS. I tested stage1 relocation by changing the key being used to the old one and placing stage1 in the right place, but leaving everything else intact, which worked. It also works with the newer key. Stage2 I tested by simply changing the location in RAM where it was saved to and launched from. This also worked.

I would highly recommend this be tested by people with hardmods before being merged. I am not extremely confident in my understanding of PIC/PIE.

I also took the opportunity to try to improve the _start.s file in stage1, and the Makefiles.
